### PR TITLE
Remove reset button from project and user filters

### DIFF
--- a/components/Project/ProjectFilterContent.tsx
+++ b/components/Project/ProjectFilterContent.tsx
@@ -1,11 +1,11 @@
 import React, { ChangeEvent, useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { Select, Stack, Grid, ActionIcon, Group, Switch, MultiSelect } from '@mantine/core'
+import { Select, Stack, Grid, ActionIcon, Switch, MultiSelect } from '@mantine/core'
 import { DateInput } from '@mantine/dates'
 import { useForm } from '@mantine/form'
 import { useMediaQuery } from '@mantine/hooks'
 
-import { IconArrowUp, IconArrowDown, IconTrash } from '@tabler/icons-react'
+import { IconArrowUp, IconArrowDown } from '@tabler/icons-react'
 import Theme from 'src/app/theme'
 
 import { Order } from '@/entities/HelpTypes/Order'

--- a/components/Project/ProjectFilterContent.tsx
+++ b/components/Project/ProjectFilterContent.tsx
@@ -99,11 +99,6 @@ const ProjectFilterContent = (props: ProjectFilterContentProps) => {
     Url.setUrlParam(router, pathname, searchQuery, 'order', value)
   }
 
-  const reset = () => {
-    form.reset()
-    router.push(`${pathname}`)
-  }
-
   const isMobile = useMediaQuery(`(max-width: ${Theme.breakpoints?.lg})`)
 
   return (
@@ -220,12 +215,6 @@ const ProjectFilterContent = (props: ProjectFilterContentProps) => {
             value={form.values.dateFrom}
             onChange={handleDateInputChange}
           />
-
-          <Group grow mt="xs">
-            <ActionIcon color="red" onClick={reset}>
-              <IconTrash />
-            </ActionIcon>
-          </Group>
         </Stack>
       </form>
     </>

--- a/components/User/UserFilterContent.tsx
+++ b/components/User/UserFilterContent.tsx
@@ -170,12 +170,6 @@ const UserFilterContent = (props: UserFilterContentProps) => {
             onChange={handleDepartmentChange}
             disabled={!form.values.facility}
           />
-
-          <Group grow mt="xs">
-            <ActionIcon color="red" onClick={reset}>
-              <IconTrash />
-            </ActionIcon>
-          </Group>
         </Stack>
       </form>
     </>

--- a/components/User/UserFilterContent.tsx
+++ b/components/User/UserFilterContent.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { Select, Stack, Grid, ActionIcon, Group, MultiSelect } from '@mantine/core'
+import { Select, Stack, Grid, ActionIcon, MultiSelect } from '@mantine/core'
 import { useForm } from '@mantine/form'
 import { useMediaQuery } from '@mantine/hooks'
 
-import { IconArrowUp, IconArrowDown, IconTrash } from '@tabler/icons-react'
+import { IconArrowUp, IconArrowDown } from '@tabler/icons-react'
 import Theme from 'src/app/theme'
 
 import { Order } from '@/entities/HelpTypes/Order'
@@ -72,11 +72,6 @@ const UserFilterContent = (props: UserFilterContentProps) => {
   const handleOrderChange = () => {
     const value = form.values.order === Order.ASC ? Order.DESC : Order.ASC
     Url.setUrlParam(router, pathname, searchQuery, 'order', value)
-  }
-
-  const reset = () => {
-    form.reset()
-    router.push(`${pathname}`)
   }
 
   const isMobile = useMediaQuery(`(max-width: ${Theme.breakpoints?.lg})`)


### PR DESCRIPTION
As syncing form and url state bidirectionally is proving tremendously challenging and we have other tasks to do, each form value can already be reseted individually.

Will try later to hook everything with a zustand store using:
- https://codesandbox.io/p/sandbox/zustand-state-with-url-hash-demo-f29b88?file=%2Fsrc%2Fcomponents%2Fcontrols.tsx%3A8%2C39-8%2C47
- https://zustand.docs.pmnd.rs/guides/connect-to-state-with-url-hash